### PR TITLE
Set start_url to /app/groups

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,7 @@ export default defineNuxtConfig({
     routeRules: {
       "/": { prerender: true },
       "/*": { prerender: true },
+      "/app/": { redirect: "/app/groups" },
     },
   },
   pwa: {
@@ -40,6 +41,7 @@ export default defineNuxtConfig({
       name: "PeerSplit | Track and split group expenses. 100% free, 100% private.",
       short_name: "PeerSplit",
       theme_color: "#89a1f0",
+      start_url: "/app",
       icons: [
         {
           src: "pwa-64x64.png",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,7 +29,6 @@ export default defineNuxtConfig({
     routeRules: {
       "/": { prerender: true },
       "/*": { prerender: true },
-      "/app/": { redirect: "/app/groups" },
     },
   },
   pwa: {
@@ -41,7 +40,7 @@ export default defineNuxtConfig({
       name: "PeerSplit | Track and split group expenses. 100% free, 100% private.",
       short_name: "PeerSplit",
       theme_color: "#89a1f0",
-      start_url: "/app",
+      start_url: "/app/groups",
       icons: [
         {
           src: "pwa-64x64.png",


### PR DESCRIPTION
Set `start_url` to `/app/groups` so when the PWA is installed, the app is opened on the groups and not the landing page.

There's another issue https://github.com/tanayvk/peersplit/issues/2 that in combination with this will improve the experience of the PWA notably.